### PR TITLE
Reorder quality profiles, add MP3_320, remove unused dependencies, group binary dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,7 +307,6 @@ dependencies = [
  "anyhow",
  "block-modes",
  "blowfish",
- "byteorder",
  "clap",
  "env_logger",
  "futures",
@@ -349,9 +348,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+checksum = "95b3f3e67048839cb0d0781f445682a35113da7121f7c949db0e2be96a4fbece"
 dependencies = [
  "humantime",
  "is-terminal",
@@ -418,9 +417,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+checksum = "da0290714b38af9b4a7b094b8a37086d1b4e61f2df9122c3cad2577669145335"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -433,9 +432,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -443,15 +442,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+checksum = "0f4fb8693db0cf099eadcca0efe2a5a22e4550f98ed16aba6c48700da29597bc"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -460,15 +459,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -477,21 +476,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
 
 [[package]]
 name = "futures-task"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
 
 [[package]]
 name = "futures-util"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1313,9 +1312,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6093bad37da69aab9d123a8091e4be0aa4a03e4d601ec641c327398315f62b64"
+checksum = "ff1bc3d3f05aff0403e8ac0d92ced918ec05b666a43f83297ccef5bea8a3d449"
 dependencies = [
  "winapi-util",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,14 @@ readme = "README.md"
 keywords = ["deezer", "downloader"]
 description = "crate to download music from deezer"
 
+[features]
+binary = ["clap", "env_logger", "futures"]
+
 [dependencies]
-reqwest = {version = "0.11.7", features = ["json", "cookies"]}
-serde = {version = "1.0.130", features = ["derive"] }
+reqwest = { version = "0.11.7", features = ["json", "cookies"] }
+serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.72"
 md5 = "0.7.0"
-byteorder = "1.4.3"
 hex = "0.4.3"
 hex-literal = "0.3.4"
 block-modes = "0.8.1"
@@ -23,7 +25,14 @@ id3 = "0.6.6"
 tokio = { version = "1.23.0", features = ["full"] }
 anyhow = "1.0.68"
 log = "0.4.17"
-env_logger = "0.10.0"
-clap = { version = "4.0.30", features = ["derive"] }
-futures = "0.3.25"
 indicatif = "0.17.7"
+
+# binary dependencies
+clap = { version = "4.0.30", features = ["derive"], optional = true }
+env_logger = { version = "0.10.0", optional = true }
+futures = { version = "0.3.25", optional = true }
+
+
+[[bin]]
+name = "deezer_downloader"
+required-features = ["binary"]

--- a/src/downloader.rs
+++ b/src/downloader.rs
@@ -129,11 +129,15 @@ impl Downloader {
                     "formats": [
                         {
                             "cipher": "BF_CBC_STRIPE",
-                            "format": "MP3_64"
+                            "format": "MP3_320"
                         },
                         {
                             "cipher": "BF_CBC_STRIPE",
                             "format": "MP3_128"
+                        },
+                        {
+                            "cipher": "BF_CBC_STRIPE",
+                            "format": "MP3_64"
                         },
                         {
                             "cipher": "BF_CBC_STRIPE",
@@ -191,7 +195,6 @@ impl Downloader {
                 }
             })
             .collect();
-
 
         match decrypted_song {
             Ok(song) => Ok(song.into_iter().flatten().collect()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,11 @@
-use std::{fs, path::PathBuf, sync::{Arc, atomic::{AtomicUsize, Ordering}}};
+use std::{
+    fs,
+    path::PathBuf,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+};
 
 use clap::{Parser, Subcommand};
 use deezer_downloader::{song::Song, Downloader, Playlist, SongMetadata};
@@ -98,9 +105,7 @@ async fn main() -> anyhow::Result<()> {
                 .tracks
                 .data
                 .iter()
-                .map(|song| {
-                    filename_from_metadata(song)
-                })
+                .map(|song| filename_from_metadata(song))
                 .collect();
             // INFO: this writes all song names into m3u8 file regardless of download status
             fs::write(
@@ -141,7 +146,11 @@ async fn main() -> anyhow::Result<()> {
                 }));
             }
             join_all(tasks).await;
-            println!("DOWNLOADED: {} OUT OF {}", cnt.load(Ordering::Relaxed), playlist.len);
+            println!(
+                "DOWNLOADED: {} OUT OF {}",
+                cnt.load(Ordering::Relaxed),
+                playlist.len
+            );
             pb.finish_and_clear();
         }
     }


### PR DESCRIPTION
List of changes:
- Reordered the quality profiles and put MP3_128 on top of MP3_64
- Added MP3_320 as a quality profile
- Removed unused dependencies
- Grouped binary dependencies under the feature flag "binary" so users of the crate don't include useless dependencies 